### PR TITLE
v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,9 @@ Spring Boot では Executable Jar ( ライブラリや静的リソースなど�
 1. コンソールから 「 gradlew build 」 を実行
 1. サブプロジェクトの `build/libs` 直下に jar が出力されるので Java8 以降の実行環境へ配布
 1. 実行環境でコンソールから 「 java -jar xxx.jar 」 を実行して起動
+    - サブプロジェクト同士の依存が発生する jar は xxx-exec.jar に読み換えてください
 
 > 実行引数に 「 --spring.profiles.active=[プロファイル名]」 を追加する事で application.yml の設定値を変更できます。
-
-> 手元で確認した際 micro-web のビルドに失敗することがありました。ビルド失敗時は以下手順で分割ビルドを試してみてください。
-
-1. コンソールから 「 gradlew build -x :micro-web:build 」 を実行
-1. コンソールから 「 gradlew :micro-web:build 」 を実行
 
 ### 依存ライブラリ
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext {
-    springCloudVersion = 'Brixton.SR6'
-    springBootVersion = '1.4.1.RELEASE'
+    springCloudVersion = 'Camden.SR3'
+    springBootVersion = '1.4.3.RELEASE'
   }
   repositories {
     jcenter()
@@ -12,11 +12,11 @@ buildscript {
 }
 
 allprojects {
-  version = "1.2.1"
+  version = "1.3.0"
 }
 
 subprojects {
-  apply plugin: "spring-boot"
+  apply plugin: "org.springframework.boot"
 
   sourceCompatibility = '1.8'
   targetCompatibility = '1.8'
@@ -35,6 +35,7 @@ subprojects {
 
   springBoot {
     executable = true
+    buildInfo()
   }
 
   repositories {
@@ -49,7 +50,7 @@ subprojects {
   }
     
   dependencies {
-    compileOnly "org.projectlombok:lombok:1.16.8"
+    compileOnly "org.projectlombok:lombok:1.16.12"
     compile "org.springframework.cloud:spring-cloud-starter-eureka"
     compile "org.springframework.cloud:spring-cloud-starter-feign"
     compile "org.springframework.cloud:spring-cloud-starter-sleuth"
@@ -62,18 +63,18 @@ subprojects {
     compile "org.hibernate:hibernate-java8"
     compile "org.ehcache:ehcache:3.1.+"
     compile "javax.cache:cache-api:1.0.0"
-    compile "com.zaxxer:HikariCP:2.4.+"
+    compile "com.zaxxer:HikariCP:2.5.+"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.8.+"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.+"
-    compile "org.eclipse.collections:eclipse-collections:7.1.0"
-    compile "org.eclipse.collections:eclipse-collections-api:7.1.0"
+    compile "org.eclipse.collections:eclipse-collections:8.0.0"
+    compile "org.eclipse.collections:eclipse-collections-api:8.0.0"
     compile "commons-io:commons-io:2.5"
-    compile "org.apache.commons:commons-lang3:3.4"
-    compile "com.ibm.icu:icu4j:57.1"
+    compile "org.apache.commons:commons-lang3:3.5"
+    compile "com.ibm.icu:icu4j:58.2"
     compile "org.jolokia:jolokia-core:1.3.3"
     compile fileTree(dir: 'libs', includes: ['*.jar'])
     runtime "com.h2database:h2:1.4.+"
-    testCompileOnly "org.projectlombok:lombok:1.16.8"
+    testCompileOnly "org.projectlombok:lombok:1.16.12"
     testCompile "org.springframework.boot:spring-boot-starter-test"
   }
 }
@@ -98,5 +99,5 @@ project(':micro-web') {
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = "3.0"
+  gradleVersion = "3.2.1"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip

--- a/micro-app/build.gradle
+++ b/micro-app/build.gradle
@@ -1,8 +1,9 @@
 bootRepackage {
   mainClass = 'sample.MicroApp'
+  classifier = 'exec'
 }
 
 dependencies {
-  compile "de.codecentric:spring-boot-admin-server:1.4.1"
-  compile "de.codecentric:spring-boot-admin-server-ui:1.4.1"
+  compile "de.codecentric:spring-boot-admin-server:1.4.4"
+  compile "de.codecentric:spring-boot-admin-server-ui:1.4.4"
 }

--- a/micro-asset/build.gradle
+++ b/micro-asset/build.gradle
@@ -1,3 +1,4 @@
 bootRepackage {
   mainClass = 'sample.microasset.MicroAsset'
+  classifier = 'exec'
 }


### PR DESCRIPTION
- 依存ライブラリの更新
    - Spring Cloud Brixton.SR6 to Camden.SR3
    - Spring Boot 1.4.1 to 1.4.3
    - Spring Boot Admin 1.4.1 to 1.4.4
    - Gradle 3.0 to 3.2.1
- jar に build-info.properties を追加
- Spring Boot 同士のプロジェクト依存定義不十分だったので修正
    - `bootRepackage.classifier = 'exec'` を追加
